### PR TITLE
chore: add basic gh workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Fetch and update latest `maven` pkgs
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+      time: '00:00'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+
+  # Fetch and update latest `github-actions` pkgs
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      time: '00:00'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,5 @@ updates:
       time: '00:00'
     open-pull-requests-limit: 10
     commit-message:
-      prefix: fix
-      prefix-development: chore
+      prefix: chore
       include: scope

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+# Inherit base settings from https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml
+_extends: .github
+name-template: REST List Parameter v$RESOLVED_VERSION
+tag-template: rest-list-parameter-$RESOLVED_VERSION
+version-template: $MAJOR.$MINOR.$PATCH
+
+# Basic SemVer version resolver
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 # Inherit base settings from https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml
 _extends: .github
-name-template: REST List Parameter v$RESOLVED_VERSION
-tag-template: rest-list-parameter-$RESOLVED_VERSION
+name-template: MinIO Plugin v$RESOLVED_VERSION
+tag-template: minio-$RESOLVED_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
 
 # Basic SemVer version resolver

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,14 @@ name: CodeQL Analysis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
+    paths-ignore:
+      - '.github/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ master ]
+    paths-ignore:
+      - '.github/**'
   schedule:
     - cron: '0 10 * * 3'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '0 10 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: [ 'java' ]
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+          queries: +security-and-quality
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
+      - '**/*.md'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
+      - '**/*.md'
   schedule:
     - cron: '0 10 * * 3'
 

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -2,7 +2,7 @@ name: Update Release Draft
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -1,0 +1,17 @@
+name: Update Release Draft
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update_release_draft:
+    name: Update release draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Release Draft
+        uses: release-drafter/release-drafter@v5.12.1
+        with:
+          publish: ${{ contains(github.event.head_commit.message, '[maven-release-plugin] prepare release') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -1,0 +1,52 @@
+name: Upload release artifact
+
+on:
+  release:
+    types: [ published ]
+
+env:
+  PROJECT: rest-list-parameter
+
+jobs:
+  build-upload-artifact:
+    name: Build and upload artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Dmaven.test.skip=true
+
+      - name: Set variables
+        id: set-variables
+        run: |
+          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          asset_path="target/${PROJECT}.hpi"
+          asset_name="${PROJECT}-${version}.hpi"
+          echo "Version is ${version}"
+          echo "Asset_Path is ${asset_path}"
+          echo "Asset_Name is ${asset_name}"
+          echo "::set-output name=asset-path::${asset_path}"
+          echo "::set-output name=asset-name::${asset_name}"
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ steps.set-variables.outputs.asset-path }}
+          asset_name: ${{ steps.set-variables.outputs.asset-name }}
+          asset_content_type: application/java-archive

--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -26,6 +26,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Dmaven.test.skip=true
 

--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 env:
-  PROJECT: rest-list-parameter
+  PROJECT: minio-plugin
 
 jobs:
   build-upload-artifact:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>io.jenkins.tools.incrementals</groupId>
+        <artifactId>git-changelist-maven-extension</artifactId>
+        <version>1.2</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Minio plugin
+
+[![Build Status](https://ci.jenkins.io/job/Plugins/job/minio-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/minio-plugin/job/master/)
+
 Minio plugin for Jenkins.
 
 Plugin is used to send files to Minio.


### PR DESCRIPTION
**Description**

Stumbled over Min.io  and this plugin today whilst researching dependency caching and noticed that this repository was lacking some default GitHub workflows.
I thought why not open a PR to add the workflows found in many of the new Jenkins plugin repositories.
Feel free to give me feedback, and I shall implement it as soon as I can or close this PR if you think this is not what you want to do.
Either way, nice little plugin :+1: !

**Changes**

* add build badge to readme
* add dependabbot config
* add CodeQL GitHub Action workflow
* add Release Drafter config with GitHub Action workflow (this workflow should automatically creates a GitHub release once a mvn release commit is detected)
* add a GitHub Action workflow to build and upload a .hpi file to a new GH release

**Issues**

* n/a