### PR TITLE
chore(pom): update pom.xml format and use bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.15</version>
-        <relativePath />
+        <relativePath/>
     </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>minio</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
-    <packaging>hpi</packaging>
+
     <properties>
-        <jenkins.version>2.243</jenkins.version>
+        <revision>1.1.1</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/minio-plugin</gitHubRepo>
+        <jenkins.version>2.249.3</jenkins.version>
+        <bom.artifactId>2.249.x</bom.artifactId>
+        <bom.version>20</bom.version>
         <java.level>8</java.level>
         <powermock.version>2.0.2</powermock.version>
     </properties>
+
     <name>Minio Plugin</name>
-    <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>minio</artifactId>
+    <url>https://github.com/${gitHubRepo}</url>
+    <version>${revision}${changelist}</version>
+    <packaging>hpi</packaging>
+
     <licenses>
         <license>
             <name>MIT License</name>
@@ -25,23 +35,69 @@
         </license>
     </licenses>
 
-    <!-- If you want this to appear on the wiki page: -->
     <developers>
-      <developer>
-        <id>sleepy</id>
-        <name>Ronald Kamphuis</name>
-        <email />
-      </developer>
+        <developer>
+            <id>sleepy</id>
+            <name>Ronald Kamphuis</name>
+            <email/>
+        </developer>
     </developers>
 
-    <!-- Assuming you want to host on @jenkinsci: -->
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/${gitHubRepo}</url>
+    </issueManagement>
+
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
+    </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-${bom.artifactId}</artifactId>
+                <version>${bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>7.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.1-jre</version>
+        </dependency>
+    </dependencies>
 
     <repositories>
         <repository>
@@ -56,53 +112,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.minio</groupId>
-            <artifactId>minio</artifactId>
-            <version>7.1.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.23</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.3.14</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.20</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>30.1-jre</version>
-        </dependency>
-    </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>jenkins-bom</artifactId>
-                <version>${jenkins-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>
@@ -110,7 +119,8 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
                     <minimumJavaVersion>1.8</minimumJavaVersion>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader> <!-- Needed for Guava version in Minio client -->
+                    <!-- Needed for Guava version in Minio client -->
+                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <bom.artifactId>2.249.x</bom.artifactId>
         <bom.version>20</bom.version>
         <java.level>8</java.level>
-        <powermock.version>2.0.2</powermock.version>
     </properties>
 
     <name>Minio Plugin</name>


### PR DESCRIPTION
### Description

Since I noticed your `pom.xml` not using the `bom` dependency management for core dependencies yet I decided to update your pom and make use of `bom` [dependency management](https://github.com/jenkinsci/bom).

### WARNING

This PR raises the min Jenkins version from `2.243` to `2.249.3` due to the dependency `bom` only supporting LTS versions and me not wanting to downgrade the min required Jenkins version. (Feedback on this is wanted!)

### Changes

* update pom.xml inner file formatting
* change dependency management to use [bom](https://github.com/jenkinsci/bom)
* update to the latest compatible patch version (7.1.4) of minio-java (8.x.y seems to cause errors with the maven enforcer plugin)

### Issues

* n/a