### PR TITLE
Add option to ignore errors on downloading non-existing objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
         <revision>1.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/minio-plugin</gitHubRepo>
-        <jenkins.version>2.249.3</jenkins.version>
-        <bom.artifactId>2.249.x</bom.artifactId>
-        <bom.version>21</bom.version>
+        <jenkins.version>2.289.1</jenkins.version>
+        <bom.artifactId>2.289.x</bom.artifactId>
+        <bom.version>876.vc43b4c6423b6</bom.version>
         <java.level>8</java.level>
     </properties>
 

--- a/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/config.jelly
@@ -21,4 +21,8 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry field="failOnNonExisting" title="Fail on non-existing">
+        <f:checkbox />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-failOnNonExisting.html
+++ b/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-failOnNonExisting.html
@@ -1,0 +1,3 @@
+<div align="help">
+    Uncheck this if you want the build to continue when a non-existing file is encountered.
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This adds functionality to ignore errors when trying to download an object from Minio that does not exist. Also slightly improves output from pipelines for easier debugging.

Resolves #40 
Resolves #32 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
