### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2.5.0
+      uses: actions/setup-java@v3.0.0
       with:
         distribution: temurin
         java-version: 8

--- a/.github/workflows/upload-release-artifact.yml
+++ b/.github/workflows/upload-release-artifact.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Cache local Maven repository
         uses: actions/cache@v2.1.7


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage
