### PR TITLE
Support downloading a directory

### DIFF
--- a/src/main/java/io/jenkins/plugins/minio/download/MinioDownloadBuildStep.java
+++ b/src/main/java/io/jenkins/plugins/minio/download/MinioDownloadBuildStep.java
@@ -26,6 +26,7 @@ public class MinioDownloadBuildStep extends Builder implements SimpleBuildStep {
     private String credentialsId;
     private final String bucket;
     private final String file;
+    private boolean recursive = false;
     private String excludes;
     private String targetFolder;
     private boolean failOnNonExisting = true;
@@ -51,6 +52,11 @@ public class MinioDownloadBuildStep extends Builder implements SimpleBuildStep {
         } catch (Exception e) {
             setFailed(run, listener, e);
         }
+    }
+
+    @DataBoundSetter
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
     }
 
     @DataBoundSetter
@@ -92,6 +98,10 @@ public class MinioDownloadBuildStep extends Builder implements SimpleBuildStep {
 
     public String getFile() {
         return file;
+    }
+
+    public boolean getRecursive() {
+        return recursive;
     }
 
     public String getExcludes() {

--- a/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/config.jelly
@@ -21,6 +21,10 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry field="recursive" title="Rescursive">
+        <f:checkbox />
+    </f:entry>
+
     <f:entry field="failOnNonExisting" title="Fail on non-existing">
         <f:checkbox />
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-file.html
+++ b/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-file.html
@@ -1,4 +1,6 @@
 <div align="help">
-    Indicates what file should be downloaded.
+    Indicates the name of a file to download.
+    If the file is a directory, select <tt>recurseive</tt> to downlaod it,
+    otherwise an error is raised.
     Environment variables can be used with the ${...} syntax.
 </div>

--- a/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-recursive.html
+++ b/src/main/resources/io/jenkins/plugins/minio/download/MinioDownloadBuildStep/help-recursive.html
@@ -1,0 +1,8 @@
+<div align="help">
+    Indicates that all files in a directory (recursively) should be downloaded.
+    If the file identified in <tt>file</tt> is a directory, all of its contents
+    are downloaded to <tt>targetFolder</tt>. To download all the files in the
+    bucked specify <tt>file</tt> as an empty string and <tt>recursive</tt> as
+    <tt>true</tt>.
+</div>
+


### PR DESCRIPTION
Add a new "recursive" checkbox to the download step. This instructs the
download step to recursively download all files matching the name in the
'file' option and store them in a matching hierarchy locally.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Manually tested with the following pipeline (and variations):

```groovy
// vim: ft=groovy

def MINIO_HOST='https://somewhere:9000'
def MINIO_CREDS='minio'
def MINIO_BUCKET='xxx-main'

pipeline {
    agent {
        label 'pool'
    }

    options {
        buildDiscarder(logRotator(daysToKeepStr: '10', numToKeepStr: '10'))
    }

    parameters {
        string(name: 'VERSION',
               description: 'Version of sftcli RPM to build (no v prefix)',
               defaultValue: 'dev_build')
    }


    stages {
        stage('Download existing builds') {
            steps {
                cleanWs()
                minioDownload( bucket:        MINIO_BUCKET,
                               host:          MINIO_HOST,
                               credentialsId: MINIO_CREDS,
                               failOnNonExisting: false,
                               file:         '',
                               recursive: true,
                               targetFolder: 'rpmbuild/RPMS/x86_64' )
            }
        }

        stage('Build rpm') {
            steps {
                sh """
                    echo "BUILD"
                    mkdir -p rpmbuild/RPMS/x86_64
                    echo "test" > rpmbuild/RPMS/x86_64/test-${VERSION}-1.rpm
                    echo "test" > rpmbuild/RPMS/x86_64/test-${VERSION}-2.rpm
                    echo "test" > rpmbuild/RPMS/x86_64/test-${VERSION}-3.rpm
                    echo "test" > rpmbuild/RPMS/x86_64/test-${VERSION}-4.rpm

                """
            }
        }

        stage('Upload new builds') {
            steps {
                minio( bucket:        MINIO_BUCKET,
                       host:          MINIO_HOST,
                       credentialsId: MINIO_CREDS,
                       includes:     'rpmbuild/RPMS/x86_64/*',
                       targetFolder: '' )
            }
        }
    }
}


```

And the following freestyle:

![image](https://user-images.githubusercontent.com/10584846/166737904-03a5080b-33e6-4f20-bcee-f9a9b038aad5.png)

