### PR TITLE
Bump Minio from 7.1.4 to 8.5.17, bump plugin to latest 5.12, bump revision to 1.3.4

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,57 +1,28 @@
+---
 name: cd
 on:
   workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only
+          → Skip the release job
+        default: false
   check_run:
     types:
       - completed
 
+permissions:
+  checks: read
+  contents: write
+
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
-    steps:
-      - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.0
-        id: verify-ci-status
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output_result: true
-
-      - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          name: next
-          tag: next
-          version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.0.0
-        id: interesting-categories
-        if: steps.verify-ci-status.outputs.result == 'success'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [validate]
-    if: needs.validate.outputs.should_release == 'true'
-    steps:
-    - name: Check out
-      uses: actions/checkout@v2.4.0
-      with:
-        fetch-depth: 0
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2.5.0
-      with:
-        distribution: temurin
-        java-version: 8
-    - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
-buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null ],
-    [ platform: "windows", jdk: "8", jenkins: null ],
-    [ platform: "windows", jdk: "11", jenkins: null ],
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <revision>1.3.3</revision>
+        <revision>1.3.4</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/minio-plugin</gitHubRepo>
         <jenkins.baseline>2.479</jenkins.baseline>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.33</version>
+        <version>5.12</version>
         <relativePath />
     </parent>
 
@@ -13,11 +13,10 @@
         <revision>1.3.3</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/minio-plugin</gitHubRepo>
-        <jenkins.version>2.289.1</jenkins.version>
-        <bom.artifactId>2.289.x</bom.artifactId>
-        <bom.version>1135.va_4eeca_ea_21c1</bom.version>
-        <java.level>8</java.level>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
+
 
     <name>Minio Plugin</name>
     <groupId>io.jenkins.plugins</groupId>
@@ -47,7 +46,7 @@
     </issueManagement>
 
     <scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
@@ -55,13 +54,39 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${bom.artifactId}</artifactId>
-                <version>${bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
+        <dependency>
+            <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
+            <groupId>io.jenkins.tools.bom</groupId>
+            <artifactId>bom-${jenkins.baseline}.x</artifactId>
+            <version>4628.v2b_234a_1a_20d0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.3.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>2.28.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>1.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.80</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+        </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -78,11 +103,10 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>7.1.4</version>
+            <version>8.5.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.github.spotbugs</groupId>
@@ -91,9 +115,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 
@@ -110,17 +134,4 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <minimumJavaVersion>1.8</minimumJavaVersion>
-                    <!-- Needed for Guava version in Minio client -->
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/java/io/jenkins/plugins/minio/config/GlobalMinioConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/minio/config/GlobalMinioConfiguration.java
@@ -5,7 +5,7 @@ import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import javax.annotation.Nonnull;
 
@@ -42,7 +42,7 @@ public class GlobalMinioConfiguration extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         return true;
     }

--- a/src/main/java/io/jenkins/plugins/minio/download/MinioDownloadBuildStep.java
+++ b/src/main/java/io/jenkins/plugins/minio/download/MinioDownloadBuildStep.java
@@ -7,7 +7,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.minio.CredentialsHelper;
-import io.minio.ErrorCode;
 import io.minio.errors.ErrorResponseException;
 import jenkins.tasks.SimpleBuildStep;
 
@@ -42,8 +41,8 @@ public class MinioDownloadBuildStep extends Builder implements SimpleBuildStep {
         try {
             new MinioDownloadStepExecution(run, workspace, env, launcher, listener, this).start();
         } catch (ErrorResponseException e) {
-            ErrorCode code = e.errorResponse().errorCode();
-            if ((code.equals(ErrorCode.NO_SUCH_OBJECT) || code.equals(ErrorCode.NO_SUCH_BUCKET) || code.equals(ErrorCode.NO_SUCH_KEY)) && !this.failOnNonExisting) {
+            String code = e.errorResponse().code();
+            if (( code.equals("NoSuchBucket") || code.equals("NoSuchKey")) && !this.failOnNonExisting) {
                 listener.getLogger().println(String.format(String.format("File [%s] not found in bucket [%s], but failOnNonExisting = false.", env.expand(this.file), this.bucket)));
             } else {
                 setFailed(run, listener, e);

--- a/src/test/java/io/jenkins/plugins/minio/config/GlobalMinioConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/minio/config/GlobalMinioConfigurationTest.java
@@ -1,13 +1,12 @@
 package io.jenkins.plugins.minio.config;
 
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
-import org.junit.Rule;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlTextInput;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Ronald Kamphuis
@@ -16,13 +15,13 @@ public class GlobalMinioConfigurationTest {
 
     private static final String GLOBAL_HOST = "http://localhost:9000/";
 
-    @Rule
-    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    @ClassRule
+    public static JenkinsSessionRule sr = new JenkinsSessionRule();
 
     @Test
-    public void uiAndStorage() {
-        rr.then(r -> {
-            assertNull("not set initially", GlobalMinioConfiguration.get().getConfiguration());
+    public void uiAndStorage() throws Throwable {
+        sr.then(r -> {
+            assertNull("not set initially",GlobalMinioConfiguration.get().getConfiguration());
             HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
             HtmlTextInput textbox = config.getInputByName("_.host");
             textbox.setText(GLOBAL_HOST);
@@ -30,7 +29,7 @@ public class GlobalMinioConfigurationTest {
             r.submit(config);
             assertEquals("global config page let us edit it", GLOBAL_HOST, GlobalMinioConfiguration.get().getConfiguration().getHost());
         });
-        rr.then(r -> {
+        sr.then(r -> {
             assertEquals("still there after restart of Jenkins", GLOBAL_HOST, GlobalMinioConfiguration.get().getConfiguration().getHost());
         });
     }


### PR DESCRIPTION
1. deps: bump minio dep form 7.1.4 to current latest 8.5.17, bump plugin to latest 5.12.
2. fixed deprecated usages

A fix for issue mentioned in #195 comment "Minio: Couldn't parse the specified URI". This issue will happen on Minio new version.

### Testing done

Unit test passed 
![image](https://github.com/user-attachments/assets/7d78571b-789e-4163-abf9-e13003ccfb34)
On agent test passed, file can be downloaded and uploaded
![image](https://github.com/user-attachments/assets/67d177ef-825f-42fc-981b-bac511ebf1fd)



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

