### PR TITLE
BUGFIX: don't swallow exceptions that happen during upload

### DIFF
--- a/src/main/java/io/jenkins/plugins/minio/upload/MinioStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/minio/upload/MinioStepExecution.java
@@ -71,7 +71,7 @@ public class MinioStepExecution {
         }
 
         final String targetFolder = targetFolderExpanded;
-        Arrays.asList(workspace.list(includes, excludes)).forEach(filePath -> {
+        for (FilePath filePath : workspace.list(includes, excludes)) {
             String filename = filePath.getName();
             Path path = Paths.get(filename);
             String contentType = null;
@@ -84,21 +84,14 @@ public class MinioStepExecution {
                 contentType = new MimetypesFileTypeMap().getContentType(filename);
             }
             taskListener.getLogger().println(String.format("Storing [%s] in bucket  [%s] , mime [%s] ", filename, step.getBucket(),contentType));
-            try {
-                PutObjectArgs put = PutObjectArgs.builder()
-                        .bucket(this.step.getBucket())
-                        .object(targetFolder + filename)
-                        .stream(filePath.read(), filePath.toVirtualFile().length(), -1)
-                        .contentType(contentType)
-                        .build();
-                client.putObject(put);
-
-            } catch (RuntimeException ex) {
-                throw ex;
-            } catch (Exception ex) { // Gotta catch 'em all
-                run.setResult(Result.UNSTABLE);
-            }
-        });
+            PutObjectArgs put = PutObjectArgs.builder()
+                    .bucket(this.step.getBucket())
+                    .object(targetFolder + filename)
+                    .stream(filePath.read(), filePath.toVirtualFile().length(), -1)
+                    .contentType(contentType)
+                    .build();
+            client.putObject(put);
+        }
 
         return true;
     }


### PR DESCRIPTION
Let the caller decide how to react to errors raised by the operation.

Addresses https://github.com/jenkinsci/minio-plugin/issues/242

Removes exception-catching during upload, because it's wholly unnecessary: it should be up to the caller to determine how to respond to an upload failure. Furthermore, when an upload fails, information should be provided to describe why to assist in triage.

### Testing done

- Standard on-build tests
- Run the code in production, see errors raised and builds failing, vs. simply being silently marked unstable with no further information

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
